### PR TITLE
Make tty input force close

### DIFF
--- a/lib/ttyread.js
+++ b/lib/ttyread.js
@@ -86,7 +86,7 @@ function ttyread(prompt, opts, callback) {
   function closeInput() {
     input.removeListener('data', processChar);
     input.setRawMode(false);
-    input.end();
+    input.destroy();
   };
 
   function clearScreenDown() {


### PR DESCRIPTION
After updating to Node 12. Calling .end on the open tty socket never results in a close event, only a half close. Destroy forces the close to happen.